### PR TITLE
Add simple persistency (off by default)

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -91,7 +91,7 @@ the `:upgrade' argument."
   :group 'quelpa
   :type 'string)
 
-(defcustom quelpa-persistent-cache-p nil
+(defcustom quelpa-persistent-cache-p t
   "Non-nil when quelpa's cache is saved on and read from disk."
   :group 'quelpa
   :type 'boolean)


### PR DESCRIPTION
This PR adds the ability to read in the cache and save it if `quelpa-persistent-cache-p` is non-nil. It does nothing fancy. I'm not sure whether to keep this on by default yet. Let's not for now and once the kinks are ironed out, enable it to make `quelpa-upgrade` work as people would expect.
