### PR TITLE
Allow customization of MELPA repository url.

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -104,6 +104,11 @@ If nil the update is disabled and the repo is only updated on
   :group 'quelpa
   :type 'boolean)
 
+(defcustom quelpa-melpa-repository-url "git://github.com/milkypostman/melpa.git"
+  "MELPA git repository url from which to install package-build."
+  :group 'quelpa
+  :type 'string)
+
 (defvar quelpa-initialized-p nil
   "Non-nil when quelpa has been initialized.")
 
@@ -329,7 +334,7 @@ If there is an error and no existing checkout return nil."
              (file-exists-p (expand-file-name ".git" dir)))
         (condition-case err
             (pb/checkout-git 'package-build
-                             '(:url "git://github.com/milkypostman/melpa.git")
+                             '(:url quelpa-melpa-repository-url)
                              dir)
           (error (quelpa-message t "failed to checkout melpa git repo: `%s'" (error-message-string err))
                  (file-exists-p (expand-file-name ".git" dir)))))))


### PR DESCRIPTION
Allow customization of MELPA repository url.
I need this change to be able to use https url (it's the only way to get through proxy at work).