### PR TITLE
Fix byte-compile warning

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -541,7 +541,7 @@ insert the result into the current buffer."
   (when (quelpa-setup-p)
     (let* ((recipe (quelpa-get-melpa-recipe recipe-name)))
       (when recipe
-        (if (called-interactively-p)
+        (if (called-interactively-p 'any)
             (prin1 recipe (current-buffer)))
         recipe))))
 


### PR DESCRIPTION
I got following byte-compile warning.

```
In quelpa-expand-recipe:
quelpa.el:544:14:Warning: called-interactively-p called with 0 arguments, but
    requires 1
```