### PR TITLE
Fix CI PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 sudo: required
 language: emacs-lisp
+before_script:
+  - echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" | sudo tee -a /etc/apt/sources.list.d/xenial.list
+  - echo "deb http://archive.ubuntu.com/ubuntu xenial main" | sudo tee -a /etc/apt/sources.list.d/xenial.list
+  - sudo add-apt-repository -y ppa:ubuntu-elisp:ppa
+  - sudo apt-get -qq update
+  - sudo apt-get install -qq -y python-software-properties
+  - sudo apt-get install -qq -y git mercurial subversion bzr cvs emacs24 emacs-snapshot
 script:
   ./ci/run.sh
 notifications:

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -12,20 +12,6 @@ else
     dir="$PWD"
 fi
 
-if ! dpkg -l | grep python-software-properties; then
-    sudo apt-get update
-    sudo apt-get install -qq python-software-properties
-fi
-
-if ! grep cassou /etc/apt/sources.list.d/*; then
-    sudo add-apt-repository -y ppa:cassou/emacs
-    sudo apt-get update
-fi
-
-if ! dpkg -l | grep emacs24; then
-    sudo apt-get install -qq git mercurial subversion bzr cvs emacs24 emacs24-el emacs24-common-non-dfsg emacs-snapshot-el emacs-snapshot-gtk emacs-snapshot
-fi
-
 # ERT tests
 emacs24 --batch --eval "(setq quelpa-ci-dir \"$dir\")" --load ert --load $dir/test/quelpa-test.el --funcall ert-run-tests-batch-and-exit
 rm -rf ~/.emacs.d/


### PR DESCRIPTION
I've noticed that the Travis build failed me on my other PR, it looks as if it's the previously used PPA is no longer working properly, so I've changed the relevant files to use a newer one and pull in a stable Emacs 24.5 (as the other PPA does *not* provide it).  There also seem to be problems with the packages built in the integration tests, but I'll address that in another PR.