### PR TITLE
Complete recipe names from all recipe stores

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -585,10 +585,10 @@ install them."
 (defun quelpa-interactive-candidate ()
   "Query the user for a recipe and return the name."
   (when (quelpa-setup-p)
-    (let  ((recipes (directory-files
-                     (expand-file-name "recipes" quelpa-melpa-dir)
-                     ;; this regexp matches all files except dotfiles
-                     nil "^[^.].+$")))
+    (let  ((recipes (cl-loop
+                       for dir in quelpa-melpa-recipe-stores
+                       ;; this regexp matches all files except dotfiles
+                       nconc  (directory-files dir nil "^[^.].+$"))))
       (intern (completing-read "Choose MELPA recipe: "
                                recipes nil t)))))
 


### PR DESCRIPTION
Previously quelpa would only complete package names based on files in
`~/.emacs.d/quelpa/melpa/recipes`.  This changes makes it offer all
recipe names found in any of the `quelpa-melpa-recipe-stores`
directories.