### PR TITLE
Only attempt to install requirements that aren’t already installed.

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -577,7 +577,8 @@ install them."
              (requires (package-desc-reqs pkg-desc)))
         (when requires
           (mapc (lambda (req)
-                  (unless (equal 'emacs (car req))
+                  (unless (or (equal 'emacs (car req))
+                              (package-installed-p (car req) (cadr req)))
                     (quelpa-package-install (car req))))
                 requires))
         (quelpa-package-install-file file)))))


### PR DESCRIPTION
This allows dependencies to be installed manually via another
means before running Quelpa.