### PR TITLE
Add *.elc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant*
+*.elc


### PR DESCRIPTION
When managing Quelpa as submodule of my own dotfiles repository, submodule will not become dirty if bytecompile file is excluded.