### PR TITLE
Allow to upgrade specific package from remote or local tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ First `quelpa` needs to be installed. You can install `quelpa` either from MELPA
 
 or if you are not using MELPA:
 
-```cl
+``` elisp
 (package-initialize)
 (if (require 'quelpa nil t)
     (quelpa-self-upgrade)
@@ -84,7 +84,7 @@ Evaluate this expression in your `*scratch*` buffer to bootstrap `quelpa`. Add i
 
 If you don't like `quelpa` doing self-upgrades (although this is recommended), use the following snippet instead:
 
-```cl
+``` elisp
 (package-initialize)
 (unless (require 'quelpa nil t)
   (with-temp-buffer
@@ -93,6 +93,17 @@ If you don't like `quelpa` doing self-upgrades (although this is recommended), u
 ```
 
 **Note**: `(package-initialize)` can be omitted if you are already running the command before the snippet in your init file.
+
+Or if you want to bootstrap it from a forked repository with `quelpa` source ready for modification.
+
+``` elisp
+(let ((quelpa-pkg-dir (expand-file-name "quelpa/build/quelpa" user-emacs-directory)))
+  (unless (file-exists-p quelpa-pkg-dir)
+    (with-temp-buffer
+      (url-insert-file-contents "https://raw.githubusercontent.com/kiennq/quelpa/master/quelpa.el")
+      (eval-buffer)
+      (quelpa-self-upgrade))))
+```
 
 ## Usage
 
@@ -104,7 +115,7 @@ There are two ways to install packages with `quelpa`:
 
 Check <https://melpa.org/> for any packages you would like to install. You only need to know the name:
 
-```cl
+``` elisp
 (quelpa 'magit)
 ```
 
@@ -136,7 +147,7 @@ Don't forget the quote before the recipe.
 
 Per default `quelpa` does not do anything if a package is already installed. You can customize this behavior globally by setting the variable `quelpa-upgrade-p` to `t` manually:
 
-```cl
+``` elisp
 (setq quelpa-upgrade-p t)
 ```
 
@@ -146,21 +157,23 @@ It is also possible to override this default behavior for individual packages:
 
 #### Interactive Overriding
 
-When `quelpa` is called interactively with a prefix argument (e.g `C-u M-x quelpa`) it will try to upgrade the given package even if the global variable `quelpa-upgrade-p` is set to nil.
+When `quelpa` is called interactively with a prefix argument (e.g `C-u M-x quelpa`) it will try to upgrade the given melpa package even if the global variable `quelpa-upgrade-p` is set to nil.
 
 That means `C-u M-x quelpa magit RET` will upgrade magit.
+
+When you want to upgrade packages with customized recipes that managed by `quelpa`, just run `M-x quelpa-upgrade`.
 
 Please note that the `:upgrade` parameter described below is still preferred over the prefix argument.
 
 #### Non-Interactive Overriding
 
-```cl
+``` elisp
 (quelpa 'company :upgrade t)
 ```
 
 This way `quelpa` will try to upgrade `company` even if upgrading is disabled globally.
 
-```cl
+``` elisp
 (quelpa '(ag :repo "Wilfred/ag.el" :fetcher github) :upgrade nil)
 ```
 
@@ -168,13 +181,13 @@ When used that way, `quelpa` will not upgrade `ag`. This can be used to "pin" pa
 
 ### Upgrading all packages
 
-Upgrading all your `quelpa` packages at init is one option to keep them up to date, but can slow it down considerably. Alternatively you can execute `M-x quelpa-upgrade` and upgrade every cached package.
+Upgrading all your `quelpa` packages at init is one option to keep them up to date, but can slow it down considerably. Alternatively you can execute `M-x quelpa-upgrade-all` and upgrade every cached package.
 
 This command relies on an intact cache file which is set in the `quelpa-cache-file` variable. It is updated after every `quelpa` invocation. To reset it for debugging purposes, just delete the file and better keep a backup.
 
 Normally `quelpa` also upgrades itself as well here. You can disable this by setting `quelpa-self-upgrade-p` to `nil`:
 
-```cl
+``` elisp
 (setq quelpa-self-upgrade-p nil)
 ```
 
@@ -186,19 +199,19 @@ For more information please see [MELPA's notes on stable packages](https://githu
 
 In `quelpa` there is a global variable where building of stable packages can be enabled, so that all packages are built stable (if available for the individual package):
 
-```cl
+``` elisp
 (setq quelpa-stable-p t)
 ```
 
 or you can set it just for one package by supplying `stable` as an argument:
 
-```cl
+``` elisp
 (quelpa 'anzu :stable t)
 ```
 
 or as part of the recipe itself:
 
-```cl
+``` elisp
 (quelpa '(ag :repo "Wilfred/ag.el" :fetcher github :stable t))
 ```
 
@@ -222,7 +235,7 @@ Currently `quelpa` does not remove obsolete packages after upgrades. To delete a
 
 Builds packages from single `.el` files. It works like this:
 
-```cl
+``` elisp
 (quelpa '(rainbow-mode :url "http://git.savannah.gnu.org/cgit/emacs/elpa.git/plain/packages/rainbow-mode/rainbow-mode.el" :fetcher url))
 ```
 
@@ -230,7 +243,7 @@ You specify the `:url` (either a remote or local one like `file:///path/to/file.
 
 Another example:
 
-```cl
+``` elisp
 (quelpa '(ox-rss :url "http://orgmode.org/cgit.cgi/org-mode.git/plain/contrib/lisp/ox-rss.el" :fetcher url))
 
 ```
@@ -239,7 +252,7 @@ By default upgrades are managed through file hashes, so if the content changed, 
 
 To keep the original version unmodified use the parameter `:version original`. For example:
 
-```cl
+``` elisp
 (quelpa '(queue :url "http://www.dr-qubit.org/download.php?file=predictive/queue.el" :fetcher url :version original))
 ```
 
@@ -269,13 +282,13 @@ Upon initialization `quelpa` usually updates the MELPA git repo (stored in `quel
 
 You can disable these updates by setting `quelpa-update-melpa-p` to `nil` before requiring `quelpa`:
 
-```cl
+``` elisp
 (setq quelpa-update-melpa-p nil)
 ```
 
 Or, if you don't want to use the MELPA git repo at all (e.g. if you're using `quelpa` mainly for installing packages outside of MELPA,) you can also set `quelpa-checkout-melpa-p` to `nil`:
 
-```cl
+``` elisp
 (setq quelpa-checkout-melpa-p nil)
 ```
 
@@ -294,6 +307,12 @@ This way, if no recipe is found in this custom directory, it will fallback to th
 The files themselves should be named after the package name, without any extension like `.el` or `.rcp`.
 
 Alternatively, you can also specify a list of recipes instead.
+
+#### Limiting `git` checkout depth
+
+By default, each package that managed by `quelpa` will be cloned into `quelpa-build-dir` under its own repository.
+
+This act of cloning the whole package histories may considerably increase the disk spaces consumed. We can limit that by setting `quelpa-git-clone-depth` to desired depth.
 
 ## MacOS instructions
 
@@ -389,6 +408,9 @@ When you can choose the packages that should get installed go to `All Packages` 
 Now copy `tar`, `msys-1.0.dll`, `msys-regex-1.dll`, `msys-intl-8.dll`, `msys-iconv-2.dll` from `C:\MinGW\msys\1.0\bin` to `c:\emacs\bin`
 
 Then Emacs should work with `quelpa`.
+
+Note that, from Windows 10 1703 `tar` is included in Windows by default.
+It's `bsd tar` but usable.
 
 ## Why "quelpa"?
 

--- a/quelpa.el
+++ b/quelpa.el
@@ -142,15 +142,15 @@ If nil the update is disabled and the repo is only updated on
 
 (defcustom quelpa-self-upgrade-p t
   "If non-nil upgrade quelpa itself when doing a
-  `quelpa-upgrade', otherwise only upgrade the packages in the
-  quelpa cache."
+`quelpa-upgrade-all', otherwise only upgrade the packages in the
+quelpa cache."
   :group 'quelpa
   :type 'boolean)
 
 (defcustom quelpa-git-clone-depth 1
   "If non-nil shallow clone quelpa git recipes."
   :group 'quelpa
-  :type '(choice (const :tag "Don't shallow clone" nil) 
+  :type '(choice (const :tag "Don't shallow clone" nil)
                  (integer :tag "Depth")))
 
 (defvar quelpa-initialized-p nil
@@ -216,13 +216,15 @@ On error return nil."
                               (package-buffer-info))
                      (`tar (insert-file-contents-literally file)
                            (tar-mode)
-                           (if (help-function-arglist 'package-tar-file-info)
-                               ;; legacy `package-tar-file-info' requires an arg
-                               (package-tar-file-info file)
-                             (with-no-warnings (package-tar-file-info)))))))))
+                           (with-no-warnings
+                             (if (help-function-arglist 'package-tar-file-info)
+                                 ;; legacy `package-tar-file-info' requires an arg
+                                 (package-tar-file-info file)
+                               (package-tar-file-info)))))))))
     (pcase desc
       ((pred package-desc-p) desc)
-      ((pred vectorp) (package-desc-from-legacy desc kind)))))
+      ((pred vectorp) (if (fboundp 'package-desc-from-legacy)
+                          (package-desc-from-legacy desc kind))))))
 
 (defun quelpa-archive-file-name (archive-entry)
   "Return the path of the file in which the package for ARCHIVE-ENTRY is stored."
@@ -241,9 +243,7 @@ On error return nil."
              (and pkg-desc
                   (version-list-<=
                    (version-to-list version)
-                   (if (functionp 'package-desc-vers)
-                       (package-desc-vers pkg-desc) ;old implementation
-                     (package-desc-version (car pkg-desc))))))
+                   (package-desc-version (car pkg-desc)))))
            ;; Also check built-in packages.
            (package-built-in-p name (version-to-list version)))))
 
@@ -559,9 +559,13 @@ position."
 ;;; Run Process
 
 (defun quelpa-build--run-process (dir command &rest args)
-  "In DIR (or `default-directory' if unset) run COMMAND with ARGS.
+  "In DIR run COMMAND with ARGS.
+If DIR is unset, try to run from `quelpa-build-dir'
+or variable `temporary-file-directory'.
 Output is written to the current buffer."
-  (let ((default-directory (file-name-as-directory (or dir default-directory)))
+  (let ((default-directory (file-name-as-directory (or dir
+                                                       quelpa-build-dir
+                                                       temporary-file-directory)))
         (argv (nconc (unless (eq system-type 'windows-nt)
                        (list "env" "LC_ALL=C"))
                      (if quelpa-build-timeout-executable
@@ -944,8 +948,15 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
      "\\(.*\\)" dir "git" "rev-parse" "HEAD")))
 
 (defun quelpa-build--update-git-to-ref (dir ref)
-  "Update the git repo in DIR so that HEAD is REF."
-  (quelpa-build--run-process dir "git" "reset" "--hard" ref)
+  "Update the git repo in DIR so that HEAD is REF.
+This will perform an checkout."
+  (condition-case nil
+      (quelpa-build--run-process dir "git" "cat-file" "-e" ref)
+    (error
+     ;; unshallow if needed
+     (quelpa-build--run-process dir "git" "fetch" "--unshallow" "--tags")))
+  (with-demoted-errors "Error: %s"
+    (quelpa-build--run-process dir "git" "checkout" ref))
   (quelpa-build--run-process dir "git" "submodule" "sync" "--recursive")
   (quelpa-build--run-process dir "git" "submodule" "update" "--init" "--recursive"))
 
@@ -1638,9 +1649,11 @@ Return t in each case."
         (insert (prin1-to-string quelpa-cache))))))
 
 (defun quelpa-update-cache (cache-item)
+  "Update `quelpa-cache' with new CACHE-ITEM."
   ;; try removing existing recipes by name
-  (setq quelpa-cache (cl-remove (car cache-item)
-                                quelpa-cache :key #'car))
+  (setq quelpa-cache (cl-remove-if
+                      (lambda (item) (equal (car cache-item) (car item)))
+                      quelpa-cache))
   (push cache-item quelpa-cache)
   (setq quelpa-cache
         (cl-sort quelpa-cache #'string<
@@ -1734,9 +1747,8 @@ If t, `quelpa' tries building the stable version of a package."
 (defun quelpa-package-install-file (file)
   "Workaround problem with `package-install-file'.
 `package-install-file' uses `insert-file-contents-literally'
-which causes problems when the file inserted has crlf line
-endings (Windows). So here we replace that with
-`insert-file-contents' for non-tar files."
+which causes problems when the FILE inserted has crlf line endings (Windows).
+So here we replace that with `insert-file-contents' for non-tar files."
   (if (eq system-type 'windows-nt)
       (cl-letf* ((insert-file-contents-literally-orig
                   (symbol-function 'insert-file-contents-literally))
@@ -1750,8 +1762,7 @@ endings (Windows). So here we replace that with
 
 (defun quelpa-package-install (arg)
   "Build and install package from ARG (a recipe or package name).
-If the package has dependencies recursively call this function to
-install them."
+If the package has dependencies recursively call this function to install them."
   (let* ((rcp (quelpa-arg-rcp arg))
          (file (and rcp (quelpa-build rcp))))
     (when file
@@ -1802,7 +1813,7 @@ ARGS are additional options for the quelpa recipe."
     (quelpa (append quelpa-recipe args) :upgrade t)))
 
 ;;;###autoload
-(defun quelpa-upgrade ()
+(defun quelpa-upgrade-all ()
   "Upgrade all packages found in `quelpa-cache'.
 This provides an easy way to upgrade all the packages for which
 the `quelpa' command has been run in the current Emacs session."
@@ -1812,14 +1823,28 @@ the `quelpa' command has been run in the current Emacs session."
       (when quelpa-self-upgrade-p
         (quelpa-self-upgrade))
       (setq quelpa-cache
-            (cl-remove-if (lambda (package)
-                            (or (eq package 'quelpa)
-                                (not (package-installed-p package))))
-                          quelpa-cache :key #'car))
+            (cl-remove-if-not (lambda (item) (package-installed-p (car item))) quelpa-cache))
       (mapc (lambda (item)
               (when (package-installed-p (car (quelpa-arg-rcp item)))
                 (quelpa item)))
             quelpa-cache))))
+
+;;;###autoload
+(defun quelpa-upgrade (rcp)
+  "Upgrade a package found in `quelpa-cache' with recipe RCP."
+  (interactive
+   (when (quelpa-setup-p)
+     (let* ((quelpa-melpa-recipe-stores (list quelpa-cache))
+            (name (quelpa-interactive-candidate))
+            (prefix (prefix-numeric-value current-prefix-arg)))
+       (list (assoc name quelpa-cache)))))
+  (when rcp
+    (let* ((quelpa-upgrade-p t)
+           (current-prefix-arg nil))
+      (setq quelpa-cache
+            (cl-remove-if-not (lambda (item) (package-installed-p (car item))) quelpa-cache))
+      (when (package-installed-p (car (quelpa-arg-rcp rcp)))
+        (quelpa rcp)))))
 
 ;;;###autoload
 (defun quelpa (arg &rest plist)


### PR DESCRIPTION
This is a refactored PR from #150.
In this change:
- Change from `git reset --hard` to `git checkout` so we don't accidentally lose commit when trying to test local change not commited.
- Change `quelpa-upgrade` to upgrade a quelpa managed package (choosing interactively) instead of upgrade all packages like now. To upgrade all packages, the `quelpa-upgrade-all` are provided as renamed of old `quelpa-upgrade`.
I figure this may be better since user don't accidentally upgrade all packages and have to wait for a huge time like now. Moreover, this can be used for testing local change (without make all other unrelated packages upgrading together).
- Run `quelpa-build--run-process` in `quelpa-build-dir` or `temporary-file-directory` instead of current `default-directory`. This is done to allow `quelpa-build--run-process` to still be able to functional when called with remote file opened.
Note that the output of `temporary-file-directory` is always local directory, instead of `(temporary-file-directory)` which can return remote directory.