### PR TITLE
Allow remove quelpa cache when package-delete is called

### DIFF
--- a/test/quelpa-test.el
+++ b/test/quelpa-test.el
@@ -119,3 +119,17 @@ update an existing cache item."
     (should (equal (mapcar (lambda (item) (plist-get item :stable))
                            quelpa-cache)
                    '(t t t)))))
+
+(quelpa-deftest quelpa-version-test ()
+  "Ensure that installing a package with proper version will include
+version in cache."
+  (cl-letf ((quelpa-cache nil)
+            ((symbol-function 'quelpa-package-install) (lambda (&rest _) `(20190406 1613))))
+    (quelpa '(makey :fetcher github :repo "mickeynp/makey"))
+    (should (equal quelpa-cache
+                   '((makey :fetcher github :repo "mickeynp/makey" :version (20190406 1613))))))
+  (cl-letf ((quelpa-cache nil)
+            ((symbol-function 'quelpa-package-install) #'ignore))
+    (quelpa 'makey)
+    (should (equal quelpa-cache
+                   '((makey))))))

--- a/test/quelpa-test.el
+++ b/test/quelpa-test.el
@@ -12,110 +12,110 @@
      ,@body))
 
 (quelpa-deftest quelpa-expand-recipe-test ()
-                "Should be expanding correctly as return value and into buffer."
-                (let ((package-build-rcp '(package-build :repo "melpa/package-build" :fetcher github)))
-                  (should
-                   (equal
-                    (quelpa-expand-recipe 'package-build)
-                    package-build-rcp))
-                  (should
-                   (equal
-                    (with-temp-buffer
-                      (cl-letf (((symbol-function 'quelpa-interactive-candidate)
-                                 (lambda ()
-                                   (interactive)
-                                   'package-build)))
-                        (call-interactively 'quelpa-expand-recipe))
-                      (buffer-string))
-                    (prin1-to-string package-build-rcp)))))
+  "Should be expanding correctly as return value and into buffer."
+  (let ((package-build-rcp '(package-build :repo "melpa/package-build" :fetcher github)))
+    (should
+     (equal
+      (quelpa-expand-recipe 'package-build)
+      package-build-rcp))
+    (should
+     (equal
+      (with-temp-buffer
+        (cl-letf (((symbol-function 'quelpa-interactive-candidate)
+                   (lambda ()
+                     (interactive)
+                     'package-build)))
+          (call-interactively 'quelpa-expand-recipe))
+        (buffer-string))
+      (prin1-to-string package-build-rcp)))))
 
 (quelpa-deftest quelpa-arg-rcp-test ()
-                "Ensure `quelpa-arg-rcp' always returns the correct RCP format."
-                (let ((quelpa-rcp '(quelpa :repo "quelpa/quelpa" :fetcher github))
-                      (package-build-rcp '(package-build :repo "melpa/package-build" :fetcher github)))
-                  (should
-                   (equal
-                    (quelpa-arg-rcp quelpa-rcp)
-                    quelpa-rcp))
-                  (should
-                   (equal
-                    (quelpa-arg-rcp 'package-build)
-                    package-build-rcp))
-                  (should
-                   (equal
-                    (quelpa-arg-rcp '(package-build))
-                    package-build-rcp))))
+  "Ensure `quelpa-arg-rcp' always returns the correct RCP format."
+  (let ((quelpa-rcp '(quelpa :repo "quelpa/quelpa" :fetcher github))
+        (package-build-rcp '(package-build :repo "melpa/package-build" :fetcher github)))
+    (should
+     (equal
+      (quelpa-arg-rcp quelpa-rcp)
+      quelpa-rcp))
+    (should
+     (equal
+      (quelpa-arg-rcp 'package-build)
+      package-build-rcp))
+    (should
+     (equal
+      (quelpa-arg-rcp '(package-build))
+      package-build-rcp))))
 
 (quelpa-deftest quelpa-version>-p-test ()
-                "Passed version should correctly be tested against the mocked
+  "Passed version should correctly be tested against the mocked
 `package-alist' and built-in packages."
-                (let ((package-alist (if (functionp 'package-desc-vers)
-                                         ;; old package-alist format
-                                         '((quelpa . [(20140406 1613)
-                                                      ((package-build
-                                                        (0)))
-                                                      "Emacs Lisp packages built directly from source"]))
-                                       ;; new package-alist format
-                                       '((quelpa
-                                          [cl-struct-package-desc
-                                           quelpa
-                                           (20140406 1613)
-                                           "Emacs Lisp packages built directly from source"
-                                           ((package-build (0))) nil nil "test" nil nil])))))
-                  (should-not (quelpa-version>-p 'quelpa "0"))
-                  (should-not (quelpa-version>-p 'quelpa "20140406.1613"))
-                  (should (quelpa-version>-p 'quelpa "20140406.1614"))
-                  (cl-letf (((symbol-function 'package-built-in-p)
-                             (lambda (name version) (version-list-<= version '(20140406 1613)))))
-                    (should-not (quelpa-version>-p 'foobar "0"))
-                    (should-not (quelpa-version>-p 'foobar "20140406.1613"))
-                    (should (quelpa-version>-p 'foobar "20140406.1614")))))
+  (let ((package-alist (if (functionp 'package-desc-vers)
+                           ;; old package-alist format
+                           '((quelpa . [(20140406 1613)
+                                        ((package-build
+                                          (0)))
+                                        "Emacs Lisp packages built directly from source"]))
+                         ;; new package-alist format
+                         '((quelpa
+                            [cl-struct-package-desc
+                             quelpa
+                             (20140406 1613)
+                             "Emacs Lisp packages built directly from source"
+                             ((package-build (0))) nil nil "test" nil nil])))))
+    (should-not (quelpa-version>-p 'quelpa "0"))
+    (should-not (quelpa-version>-p 'quelpa "20140406.1613"))
+    (should (quelpa-version>-p 'quelpa "20140406.1614"))
+    (cl-letf (((symbol-function 'package-built-in-p)
+               (lambda (name version) (version-list-<= version '(20140406 1613)))))
+      (should-not (quelpa-version>-p 'foobar "0"))
+      (should-not (quelpa-version>-p 'foobar "20140406.1613"))
+      (should (quelpa-version>-p 'foobar "20140406.1614")))))
 
 (quelpa-deftest quelpa-check-hash-test ()
-                "Make sure that old file hash is correctly compared with the new one
+  "Make sure that old file hash is correctly compared with the new one
   and only when it has changed the new time-stamp is returned."
-                (cl-letf* ((stamp-info '("20140413.90742" . "7e4c099e65d254f62e64b581c42ddeb3c487064b"))
-                           (hash "4935a306e358cbd0d9bd200e13ceb1e44942b323")
-                           ((symbol-function 'quelpa-build--read-from-file) (lambda (file) stamp-info))
-                           ((symbol-function 'quelpa-build--dump) (lambda (content file)))
-                           ((symbol-function 'quelpa-build--expand-source-file-list) 'ignore)
-                           ((symbol-function 'secure-hash) (lambda (&rest args) hash))
-                           ((symbol-function 'delete-directory) 'ignore)
-                           ((symbol-function 'make-directory) 'ignore)
-                           ((symbol-function 'copy-directory) 'ignore)
-                           ((symbol-function 'copy-file) 'ignore))
-                  (should-not (equal (quelpa-check-hash 'foobar nil "/" "baz")
-                                     (car stamp-info)))
-                  (setq hash (cdr stamp-info))
-                  (should (equal (quelpa-check-hash 'foobar nil "/" "baz")
-                                 (car stamp-info)))))
+  (cl-letf* ((stamp-info '("20140413.90742" . "7e4c099e65d254f62e64b581c42ddeb3c487064b"))
+             (hash "4935a306e358cbd0d9bd200e13ceb1e44942b323")
+             ((symbol-function 'quelpa-build--read-from-file) (lambda (file) stamp-info))
+             ((symbol-function 'quelpa-build--dump) (lambda (content file)))
+             ((symbol-function 'quelpa-build--expand-source-file-list) 'ignore)
+             ((symbol-function 'secure-hash) (lambda (&rest args) hash))
+             ((symbol-function 'delete-directory) 'ignore)
+             ((symbol-function 'make-directory) 'ignore)
+             ((symbol-function 'copy-directory) 'ignore)
+             ((symbol-function 'copy-file) 'ignore))
+    (should-not (equal (quelpa-check-hash 'foobar nil "/" "baz")
+                       (car stamp-info)))
+    (setq hash (cdr stamp-info))
+    (should (equal (quelpa-check-hash 'foobar nil "/" "baz")
+                   (car stamp-info)))))
 
 (quelpa-deftest quelpa-cache-test ()
-                "Ensure that installing a package with a different recipe will
+  "Ensure that installing a package with a different recipe will
 update an existing cache item."
-                (cl-letf ((quelpa-cache nil)
-                          ((symbol-function 'quelpa-package-install) 'ignore))
-                  (quelpa '(makey :fetcher github :repo "mickeynp/makey"))
-                  (quelpa 'makey)
-                  (should (equal quelpa-cache '((makey))))))
+  (cl-letf ((quelpa-cache nil)
+            ((symbol-function 'quelpa-package-install) 'ignore))
+    (quelpa '(makey :fetcher github :repo "mickeynp/makey"))
+    (quelpa 'makey)
+    (should (equal quelpa-cache '((makey))))))
 
 (quelpa-deftest quelpa-cache-regressions ()
-                (cl-letf ((quelpa-cache nil)
-                          ((symbol-function 'quelpa-package-install) 'ignore))
-                  (quelpa '(multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el" :stable t))
-                  (should (equal quelpa-cache '((multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el" :stable t))))
-                  (let ((quelpa-stable-p t))
-                    (quelpa '(multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el")
-                            :stable nil))
-                  (should (equal quelpa-cache '((multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el"))))))
+  (cl-letf ((quelpa-cache nil)
+            ((symbol-function 'quelpa-package-install) 'ignore))
+    (quelpa '(multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el" :stable t))
+    (should (equal quelpa-cache '((multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el" :stable t))))
+    (let ((quelpa-stable-p t))
+      (quelpa '(multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el")
+              :stable nil))
+    (should (equal quelpa-cache '((multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el"))))))
 
 (quelpa-deftest quelpa-stable-test ()
-                (cl-letf ((quelpa-cache nil)
-                          ((symbol-function 'quelpa-package-install) 'ignore))
-                  (quelpa '(2048-game :fetcher hg :url "https://bitbucket.org/zck/2048.el" :stable t))
-                  (quelpa 'elx :stable t)
-                  (let ((quelpa-stable-p t))
-                    (quelpa 'imgur))
-                  (should (equal (mapcar (lambda (item) (plist-get item :stable))
-                                         quelpa-cache)
-                                 '(t t t)))))
+  (cl-letf ((quelpa-cache nil)
+            ((symbol-function 'quelpa-package-install) 'ignore))
+    (quelpa '(2048-game :fetcher hg :url "https://bitbucket.org/zck/2048.el" :stable t))
+    (quelpa 'elx :stable t)
+    (let ((quelpa-stable-p t))
+      (quelpa 'imgur))
+    (should (equal (mapcar (lambda (item) (plist-get item :stable))
+                           quelpa-cache)
+                   '(t t t)))))


### PR DESCRIPTION
This is a refactored PR from #150.
In this change:
- Allow `package-delete` to also remove `quelpa` cache.
So next time we upgrade all packages, the removed package will not be reinstalled again.

I have to advise `package-delete` for seamlessly integration between `quelpa` and `package.el`. Since `quelpa` is using `package.el` to install package, user can delete `quelpa` package through `package-delete` too.
So we have to advise `package-delete` (this is `:after` advise which doesn't affect `package-delete` behavior) to update `quelpa-cache` accordingly.