### PR TITLE
Add quelpa-upgrade-all-maybe – upgrade every X days

### DIFF
--- a/README.org
+++ b/README.org
@@ -123,6 +123,13 @@ Alternatively, you may upgrade all Quelpa-installed packages using =M-x quelpa-u
 
 By default, when upgrading all packages, Quelpa also upgrades itself.  Disable this by setting variable =quelpa-self-upgrade-p= to =nil=.
 
+To run =quelpa-upgrade-all= at most every 7 days, after all the init files are loaded:
+
+#+BEGIN_SRC elisp
+(setq quelpa-upgrade-interval 7)
+(add-hook #'after-init-hook #'quelpa-upgrade-all-maybe)
+#+END_SRC
+
 ** Managing packages
 
 Quelpa installs packages using Emacs's built-in package library, =package.el=, so after installing a package with Quelpa, you can view its status and remove it using =M-x list-packages RET=.  Note that deleting a package this way does not yet affect Quelpa's cache, so Quelpa will still consider the package to have been installed with Quelpa.

--- a/quelpa.el
+++ b/quelpa.el
@@ -153,6 +153,11 @@ quelpa cache."
   :type '(choice (const :tag "Don't shallow clone" nil)
                  (integer :tag "Depth")))
 
+(defcustom quelpa-upgrade-interval nil
+  "Interval in days for `quelpa-upgrade-all-maybe'."
+  :group 'quelpa
+  :type 'integer)
+
 (defvar quelpa-initialized-p nil
   "Non-nil when quelpa has been initialized.")
 
@@ -1888,6 +1893,21 @@ nil."
       (quelpa-update-cache cache-item)))
   (quelpa-shutdown)
   (run-hooks 'quelpa-after-hook))
+
+;;;###autoload
+(defun quelpa-upgrade-all-maybe (&optional force)
+  "Run `quelpa-upgrade-all' if at least `quelpa-upgrade-interval' days have passed since the last run.
+With prefix FORCE, packages will all be upgraded discarding local changes."
+  (interactive "P")
+  (when quelpa-upgrade-interval
+    (let ((timestamp (expand-file-name "last_upgrade" quelpa-dir)))
+      (when (or (not (file-exists-p timestamp))
+                (> (- (time-to-seconds) ; Current time - modification time.
+                      (time-to-seconds (nth 5 (file-attributes timestamp))))
+                   (* 60 60 24 quelpa-upgrade-interval)))
+        (let ((current-prefix-arg force))
+          (quelpa-upgrade-all))
+        (write-region "" nil timestamp)))))
 
 (provide 'quelpa)
 


### PR DESCRIPTION
This patch adds the function `quelpa-upgrade-all-maybe` and the variable
`quelpa-upgrade-interval`.

`quelpa-upgrade-all-maybe` will call `quelpa-upgrade-all` if either the
timestamp-file doesn't exist or the timestamp file's modification time is more
than `quelpa-upgrade-interval` days in the past. After that the modification
time of the timestamp-file is updated.

I have refrained from using the following functions to keep compatibility with
Emacs 24:

* `file-attribute-modification-time` was introduced around 26.1. – I used `(nth
  5 (file-attributes timestamp))` instead.
* `time-to-days` was introduced around 25.1. – I used `time-to-seconds` instead.

I'm not sure if I got the prefix stuff right. I've never used it and copied the solution from stackoverflow.