### PR TITLE
Allow quelpa to also install recipe from quelpa-cache

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending for *.el files (prevents QUELPA errors)
+[*.el]
+end_of_line = lf

--- a/README.org
+++ b/README.org
@@ -103,14 +103,17 @@ You can also install packages that are not on MELPA by providing a recipe in the
   (quelpa '(discover-my-major :fetcher git :url "https://framagit.org/steckerhalter/discover-my-major.git"))
 #+END_SRC
 
+Once you installed a package with its own recipe, Quelpa will remember it and next time it can offer you to upgrade/install the package again with =M-x quelpa RET=.
+
 ** Upgrading packages
 
 By default, Quelpa does not upgrade installed packages.  You can enable upgrading globally by running =M-x customize-variable RET quelpa-upgrade-p RET=.
 
 To override the default and upgrade individual packages:
 
-+  Interactively, call =quelpa= with a universal prefix argument, like =C-u M-x quelpa RET=.
-+  From Lisp, call =quelpa= with the keyword argument =:upgrade=, like ~(quelpa 'package-name :upgrade t)~.
++ Interactively, call =quelpa= with a universal prefix argument, like =C-u M-x quelpa RET=.
++ From Lisp, call =quelpa= with the keyword argument =:upgrade=, like ~(quelpa 'package-name :upgrade t)~.
++ Interactively, call =M-x quelpa-upgrade RET=, it will list all Quelpa installed packages.
 
 When evaluating a buffer of =quelpa= calls, you may prevent a package from being upgraded by setting =:upgrade nil=, like =(quelpa 'package-name :upgrade nil)=.
 

--- a/test/quelpa-test.el
+++ b/test/quelpa-test.el
@@ -120,7 +120,10 @@ update an existing cache item."
             ((symbol-function 'quelpa-package-install) 'ignore))
     (quelpa '(makey :fetcher github :repo "mickeynp/makey"))
     (quelpa 'makey)
-    (should (equal quelpa-cache '((makey))))))
+    (should (equal quelpa-cache '((makey :fetcher github :repo "mickeynp/makey"))))
+    (quelpa '(makey :fetcher github :repo "foo/makey"))
+    (should (equal quelpa-cache '((makey :fetcher github :repo "foo/makey"))))
+    ))
 
 (quelpa-deftest cache-regressions ()
   (cl-letf ((quelpa-cache nil)


### PR DESCRIPTION
Allow `quelpa` to install recipe from `quelpa-cache` as preferred recipe. It helps smooth user experience when both installing and updating package, just using `M-x quelpa` and user can install/updating packages from both MELPA and custom cached recipes.
This tackle #163 mentioned issue, which allow `M-x quelpa` to be able to view both cached recipes and stores.

Another aspect of issue in #163 is for `M-x quelpa-upgrade` to be able to only seeing installed packages, instead of all cached recipes like now. This change also fixes that behavior.
This will make #155 deprecated, since the final goal of it is also the same, just using different approach, and likely requires user configuration changes since it introduces new mode.

After this change, the enlightened scenarios will be:
- User be able to config custom recipes in config file (single source of truth) and have them be viewable from single command `M-x quelpa`.
- User be able to just upgrade to installed package, not seeing uninstalled package with `M-x quelpa-upgrade`.