### PR TITLE
update URL

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,7 +36,7 @@ Given a recipe in [[https://github.com/melpa/melpa#recipe-format][MELPA's format
 
 =quelpa= can be used in many ways, for example to manage your personal packages, testing development versions of other packages or as a helper when developing a package to test building, compiling and installing it.
 
-To get an idea how to use it to manage your Emacs setup, take a look at the [[https://framagit.org/steckerhalter/steckemacs.el][steckemacs configuration]], which uses [[https://framagit.org/steckerhalter/quelpa-use-package][quelpa-use-package]] to integrate with =use-package=.
+To get an idea how to use it to manage your Emacs setup, take a look at the [[https://framagit.org/steckerhalter/steckemacs.el][steckemacs configuration]], which uses [[https://github.com/quelpa/quelpa-use-package][quelpa-use-package]] to integrate with =use-package=.
 
 You can build and install packages from (fetcher names in parens): Git (=git=), GitHub (=github=), Bazaar (=bzr=), Mercurial (=hg=), Subversion (=svn=), CVS (=cvs=), Darcs (=darcs=), Fossil (=fossil=) and EmacsWiki (=wiki=)
 

--- a/quelpa.el
+++ b/quelpa.el
@@ -4,7 +4,7 @@
 ;; Copyright 2014-2015, Vasilij Schneidermann <v.schneidermann@gmail.com>
 
 ;; Author: steckerhalter
-;; URL: https://framagit.org/steckerhalter/quelpa
+;; URL: https://github.com/quelpa/quelpa
 ;; Version: 0.0.1
 ;; Package-Requires: ((emacs "24.3"))
 ;; Keywords: package management build source elpa
@@ -32,7 +32,7 @@
 ;; built on-the-fly directly from source.
 
 ;; See the README for more info:
-;; https://framagit.org/steckerhalter/quelpa/blob/master/README.md
+;; https://github.com/quelpa/quelpa/blob/master/README.org
 
 ;;; Requirements:
 
@@ -159,7 +159,7 @@ quelpa cache."
 (defvar quelpa-cache nil
   "The `quelpa' command stores processed pkgs/recipes in the cache.")
 
-(defvar quelpa-recipe '(quelpa :url "https://framagit.org/steckerhalter/quelpa.git" :fetcher git)
+(defvar quelpa-recipe '(quelpa :repo "quelpa/quelpa" :fetcher github)
   "The recipe for quelpa.")
 
 ;; --- compatibility for legacy `package.el' in Emacs 24.3  -------------------


### PR DESCRIPTION
Update remaining framagit urls to GitHub.
I noticed that `M-x quelpa-self-upgrade` doesn't upgrade quelpa.