### PR TITLE
emacs-27: Load package descriptors if package.el is not initialized

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -168,10 +168,6 @@ quelpa cache."
 (defvar quelpa-recipe '(quelpa :repo "quelpa/quelpa" :fetcher github)
   "The recipe for quelpa.")
 
-(defvar package-alist)
-(defvar package--initialized)
-(declare-function package-load-all-descriptors "ext:package")
-
 ;; --- compatibility for legacy `package.el' in Emacs 24.3  -------------------
 
 (defun quelpa-setup-package-structs ()


### PR DESCRIPTION
Support for emacs-27, since it's not need to call `package-initialize` anymore in user init file.
We will need to call `package-load-all-descriptors` for `package-alist` to be properly set.
Also, change some part to `when-let`, which is emacs-25 macro, since this change is very small, I slip this into previous change altogether.