### PR TITLE
Don't show package deleted message

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -1771,7 +1771,8 @@ If the package has dependencies recursively call this function to install them."
   "Delete obsoleted packages with name NAME."
   (mapc (lambda (pkg-desc)
           (with-demoted-errors "Error deleting package: %S"
-            (package-delete pkg-desc)))
+            (let ((inhibit-message t))
+              (package-delete pkg-desc))))
         (cddr (assoc name package-alist))))
 
 ;; --- public interface ------------------------------------------------------


### PR DESCRIPTION
Dont' show package deleted message when deleting obsoleted packages.
User can still check for those from `*Message*` buffer.

This fix issue 2 in #176 