### PR TITLE
feat: add github-ssh fetcher

### DIFF
--- a/README.org
+++ b/README.org
@@ -221,7 +221,7 @@ The =github-ssh= fetcher builds packages from =github ssh= link, it's alternativ
 #+END_SRC
 
 *Note:*
-+ You should setup [Github ssh key](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) before using this.
++ You should setup [[https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent][Github ssh key]] before using this.
 + This fetcher will come handy when you want to modify the packages and contribute back without the needs of enter password everytime.
 
 ** Additional options

--- a/README.org
+++ b/README.org
@@ -212,6 +212,18 @@ It also builds multi-file packages from a local directory.  For example:
 +  Specifying a directory for =:path= does not retain existing version numbers, nor does it respect the =:version original= parameter.
 +  Paths are expanded with =expand-file-name=, so =~= in path names is expanded to the user's home directory.
 
+*** Github SSH
+
+The =github-ssh= fetcher builds packages from =github ssh= link, it's alternative of =github= fetcher which builds packages from =https= link. For example, the following recipe will clone =Quelpa= from =git@github.com:quelpa/quelpa.git= and builds it:
+
+#+BEGIN_SRC elisp
+  (quelpa '(quelpa :fetcher github-ssh :repo "quelpa/quelpa"))
+#+END_SRC
+
+*Note:*
++ You should setup [Github ssh key](https://help.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) before using this.
++ This fetcher will come handy when you want to modify the packages and contribute back without the needs of enter password everytime.
+
 ** Additional options
 
 *** Prevent updating of MELPA repo on Emacs startup

--- a/quelpa.el
+++ b/quelpa.el
@@ -952,6 +952,11 @@ This will perform an checkout or a reset if FORCE."
   (let ((url (format "https://github.com/%s.git" (plist-get config :repo))))
     (quelpa-build--checkout-git name (plist-put (copy-sequence config) :url url) dir)))
 
+(defun quelpa-build--checkout-github-ssh (name config dir)
+  "Check package NAME with config CONFIG out of github into DIR."
+  (let ((url (format "git@github.com:%s.git" (plist-get config :repo))))
+    (quelpa-build--checkout-git name (plist-put (copy-sequence config) :url url) dir)))
+
 (defun quelpa-build--checkout-gitlab (name config dir)
   "Check package NAME with config CONFIG out of gitlab into DIR."
   (let ((url (format "https://gitlab.com/%s.git" (plist-get config :repo))))


### PR DESCRIPTION
Add `github-ssh` fetcher that will conveniently  fetch from ssh link of github.