### PR TITLE
fix: call quickstart-refresh when build package failed

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -257,7 +257,9 @@ already and should not be upgraded etc)."
                                (quelpa-build--config-file-list (cdr rcp))
                                build-dir
                                quelpa-packages-dir))
-      (quelpa-build--message "Newer package has been installed. Not updating.")
+      (quelpa-build--message "Newer package has been installed. Not upgrading.")
+      (when (fboundp 'package--quickstart-maybe-refresh)
+        (package--quickstart-maybe-refresh))
       nil)))
 
 ;; --- package-build.el integration ------------------------------------------


### PR DESCRIPTION
Emacs 27 support quick start, normally the `package-quickstart-refresh` will be called by `package-install`, so it's fine for Quelap.
However, in case of we trying to upgrade the same package version, there's case that the quick start information is staled, `Quelpa` should call `package-quickstart-refresh` explicitly at that time.