### PR TITLE
quelpa-upgrade: allow to install current ref regardless of installed version

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -1797,8 +1797,8 @@ Return new package version."
   "Delete obsoleted packages with name NAME.
 With NEW-VERSION, will delete obsoleted packages that are not in same
 version."
-  (when-let* ((all-pkgs (alist-get name package-alist))
-              (new-pkg-version (or new-version
+  (when-let ((all-pkgs (alist-get name package-alist))
+             (new-pkg-version (or new-version
                                    (package-desc-version (car all-pkgs)))))
     (with-demoted-errors "Error deleting package: %S"
       (mapc (lambda (pkg-desc)

--- a/test/quelpa-test.el
+++ b/test/quelpa-test.el
@@ -138,7 +138,7 @@ update an existing cache item."
 (quelpa-deftest stable ()
   (cl-letf ((quelpa-cache nil)
             ((symbol-function 'quelpa-package-install) 'ignore))
-    (quelpa '(2048-game :fetcher hg :url "https://bitbucket.org/zck/2048.el" :stable t))
+    (quelpa '(2048-game :fetcher hg :url "https://hg.sr.ht/~zck/game-2048" :stable t))
     (quelpa 'elx :stable t)
     (let ((quelpa-stable-p t))
       (quelpa 'imgur))
@@ -170,7 +170,9 @@ update an existing cache item."
   (should-install 2048-game)
   ;; [2020-01-26 Sun 00:07] Nose repo is uncloneable due to TLS error,
   ;; but probably a local problem.
-  (should-install nose))
+  ;; There is no package nose
+  ;; (should-install nose)
+  (should-install minesweeper))
 
 (quelpa-deftest svn ()
   (should-install (confluence


### PR DESCRIPTION
This addresses #186 
With this, for local development, when local ref upgrade is triggered (`C-u C-u M-x quelpa-upgrade`), it will properly upgrade the package to local ref version, **regardless of installed version**.

This is only case where we allow upgrade (or downgrage?) to lower version.

This PR will provide a very convenient method to test with changes in development package. We can just use local ref upgrade without having to commit the changes.