### PR TITLE
fix regexp for single character package

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -1804,7 +1804,7 @@ Return new package version."
                       for store in quelpa-melpa-recipe-stores
                       if (stringp store)
                       ;; this regexp matches all files except dotfiles
-                      append (directory-files store nil "^[^.].+$")
+                      append (directory-files store nil "^[^.].*$")
                       else if (listp store)
                       append store))
             (recipe (intern (completing-read "Choose MELPA recipe: "


### PR DESCRIPTION
I found `M-x quelpa` doesn't show single chacacter packages such as `@` and `a`.

```elisp
(seq-difference
 (cl-loop
  for store in quelpa-melpa-recipe-stores
  if (stringp store)
  ;; this regexp matches all files except dotfiles
  append (directory-files store nil "^[^.].*$")
  else if (listp store)
  append store)
 (cl-loop
  for store in quelpa-melpa-recipe-stores
  if (stringp store)
  ;; this regexp matches all files except dotfiles
  append (directory-files store nil "^[^.].+$")
  else if (listp store)
  append store))
;; => ("@" "a" "f" "s")
```