### PR TITLE
quelpa: prioritize recipe-stores over quelpa-cache

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -237,6 +237,13 @@ OP is taking two version list and comparing."
   "Return non-nil if VERSION of pkg with NAME is same which what is currently installed."
   `(quelpa-version-cmp ,name ,version 'version-list-=))
 
+(defmacro quelpa--package-installed-p (package &optional min-version)
+  "Return non-nil if PACKAGE, of MIN-VERSION or newer, is installed.
+Like `package-installed-p' but properly check for built-in package even when all
+packages are not initialized."
+  `(or (package-installed-p ,package ,min-version)
+       (package-built-in-p ,package ,min-version)))
+
 (defvar quelpa--override-version-check nil)
 (defun quelpa-checkout (rcp dir)
   "Return the version of the new package given a RCP and DIR.
@@ -244,7 +251,7 @@ Return nil if the package is already installed and should not be upgraded."
   (pcase-let ((`(,name . ,config) rcp)
               (quelpa-build-stable quelpa-stable-p)
               (quelpa--override-version-check quelpa--override-version-check))
-    (unless (or (and (assq name package-alist) (not quelpa-upgrade-p))
+    (unless (or (and (quelpa--package-installed-p name) (not quelpa-upgrade-p))
                 (and (not config)
                      (quelpa-message t "no recipe found for package `%s'" name)))
       (let ((version (condition-case-unless-debug err
@@ -1698,7 +1705,7 @@ If there is an error and no existing checkout return nil."
 Return the recipe if it exists, otherwise nil."
   (cl-loop for store in quelpa-melpa-recipe-stores
            if (stringp store)
-           for file = (assoc-string name (directory-files store nil "^[^\.]+"))
+           for file = (assoc-string name (directory-files store nil "^[^.].*$"))
            when file
            return (with-temp-buffer
                     (insert-file-contents-literally
@@ -1719,7 +1726,7 @@ Return non-nil if quelpa has been initialized properly."
       (quelpa-read-cache)
       (if quelpa-checkout-melpa-p
           (unless (quelpa-checkout-melpa) (throw 'quit nil)))
-      (unless package--initialized (package-load-all-descriptors))
+      (unless package-alist (package-load-all-descriptors))
       (setq quelpa-initialized-p t))
     t))
 
@@ -1733,9 +1740,9 @@ Return non-nil if quelpa has been initialized properly."
   "Given recipe or package name ARG, return an alist '(NAME . RCP).
 If RCP cannot be found it will be set to nil"
   (pcase arg
-    (`(,a . nil) (quelpa-get-melpa-recipe (car arg)))
-    (`(,a . ,_) arg)
-    ((pred symbolp) (quelpa-get-melpa-recipe arg))))
+    (`(,name) (quelpa-get-melpa-recipe name))
+    (`(,name . ,_) arg)
+    (name (quelpa-get-melpa-recipe name))))
 
 (defun quelpa-parse-plist (plist)
   "Parse the optional PLIST argument of `quelpa'.
@@ -1807,9 +1814,10 @@ Return new package version."
                       append (directory-files store nil "^[^.].*$")
                       else if (listp store)
                       append store))
-            (recipe (intern (completing-read "Choose MELPA recipe: "
-                                             recipes nil t))))
-      (or (assoc recipe recipes) recipe))))
+            (recipe (completing-read "Choose MELPA recipe: " recipes nil t)))
+      (pcase (assoc-string recipe recipes)
+        ((and re (pred stringp)) (intern re))
+        (re re)))))
 
 (defun quelpa--delete-obsoleted-package (name &optional new-version)
   "Delete obsoleted packages with name NAME.
@@ -1889,7 +1897,7 @@ Optionally, ACTION can be passed for non-interactive call with value of:
            (current-prefix-arg nil)
            (config (append (cond ((eq action 'force) `(:force t))
                                  ((eq action 'local) `(:use-current-ref t)))
-                           `(:autoremove quelpa-autoremove-p))))
+                           `(:autoremove ,quelpa-autoremove-p))))
       (when (package-installed-p (car (quelpa-arg-rcp rcp)))
         (apply #'quelpa rcp config)))))
 
@@ -1910,7 +1918,7 @@ nil."
   (when (quelpa-setup-p) ;if init fails we do nothing
     (let* ((arg (or arg
                     (let ((quelpa-melpa-recipe-stores
-                           `(,quelpa-cache ,@quelpa-melpa-recipe-stores)))
+                           `(,@quelpa-melpa-recipe-stores ,quelpa-cache)))
                       (quelpa-interactive-candidate))))
            (quelpa-upgrade-p (if current-prefix-arg t quelpa-upgrade-p)) ;shadow `quelpa-upgrade-p'
            (quelpa-stable-p quelpa-stable-p) ;shadow `quelpa-stable-p'
@@ -1918,10 +1926,10 @@ nil."
            (cache-item (quelpa-arg-rcp arg)))
       (quelpa-parse-plist plist)
       (quelpa-parse-stable cache-item)
-      (let ((ver (apply #'quelpa-package-install arg plist)))
+      (when-let ((ver (apply #'quelpa-package-install arg plist)))
         (when quelpa-autoremove-p
-          (quelpa--delete-obsoleted-package (car cache-item) ver)))
-      (quelpa-update-cache cache-item)))
+          (quelpa--delete-obsoleted-package (car cache-item) ver))
+        (quelpa-update-cache cache-item))))
   (quelpa-shutdown)
   (run-hooks 'quelpa-after-hook))
 

--- a/test/quelpa-test.el
+++ b/test/quelpa-test.el
@@ -47,18 +47,14 @@ Defines ERT test with `quelpa-' prepended to NAME and
   "Ensure `quelpa-arg-rcp' always returns the correct RCP format."
   (let ((quelpa-rcp '(quelpa :repo "quelpa/quelpa" :fetcher github))
         (package-build-rcp '(package-build :repo "melpa/package-build" :fetcher github)))
-    (should
-     (equal
-      (quelpa-arg-rcp quelpa-rcp)
-      quelpa-rcp))
-    (should
-     (equal
-      (quelpa-arg-rcp 'package-build)
-      package-build-rcp))
-    (should
-     (equal
-      (quelpa-arg-rcp '(package-build))
-      package-build-rcp))))
+    (should (equal (quelpa-arg-rcp quelpa-rcp)
+                   quelpa-rcp))
+    (should (equal (quelpa-arg-rcp 'package-build)
+                   package-build-rcp))
+    (should (equal (quelpa-arg-rcp '(package-build))
+                   package-build-rcp))
+    (should (equal (quelpa-arg-rcp "package-build")
+                   package-build-rcp))))
 
 (quelpa-deftest version>-p ()
   "Passed version should correctly be tested against the mocked
@@ -119,7 +115,8 @@ Defines ERT test with `quelpa-' prepended to NAME and
   "Ensure that installing a package with a different recipe will
 update an existing cache item."
   (cl-letf ((quelpa-cache nil)
-            ((symbol-function 'quelpa-package-install) 'ignore))
+            ((symbol-function 'quelpa-package-install) (lambda (&rest _) '(1 0)))
+            ((symbol-function 'quelpa--delete-obsoleted-package) 'ignore))
     (quelpa '(makey :fetcher github :repo "mickeynp/makey"))
     (quelpa 'makey)
     (should (equal quelpa-cache '((makey :fetcher github :repo "mickeynp/makey"))))
@@ -129,13 +126,18 @@ update an existing cache item."
 
 (quelpa-deftest cache-regressions ()
   (cl-letf ((quelpa-cache nil)
-            ((symbol-function 'quelpa-package-install) 'ignore))
+            ((symbol-function 'quelpa-package-install) (lambda (&rest _) '(1 0)))
+            ((symbol-function 'quelpa--delete-obsoleted-package) 'ignore))
     (quelpa '(multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el" :stable t))
-    (should (equal quelpa-cache '((multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el" :stable t))))
+    (should (equal quelpa-cache '((multiple-cursors :fetcher github
+                                                    :repo "magnars/multiple-cursors.el"
+                                                    :stable t))))
     (let ((quelpa-stable-p t))
-      (quelpa '(multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el")
+      (quelpa '(multiple-cursors :fetcher github
+                                 :repo "magnars/multiple-cursors.el")
               :stable nil))
-    (should (equal quelpa-cache '((multiple-cursors :fetcher github :repo "magnars/multiple-cursors.el"))))))
+    (should (equal quelpa-cache '((multiple-cursors :fetcher github
+                                                    :repo "magnars/multiple-cursors.el"))))))
 
 (quelpa-deftest stable ()
   (cl-letf ((quelpa-cache nil)


### PR DESCRIPTION
Fix #200 
- MELPA recipes are prioritized over temporary recipe defined with `M-x quelpa`.
- User would not accidentally update package by using `quelpa`
- Temporary recipe defined with `M-x quelpa` that's not in MELPA is still being installable via `M-x quelpa`

Also:
- Fix `quelpa-interactive-candidate` to use `assoc-string` so the recipe from stores (which is list of string) will be properly selected.