### PR TITLE
ci: add emacs 27.1 to CI target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
           - 26.1
           - 26.2
           - 26.3
+          - 27.1
           - snapshot
     steps:
     - uses: purcell/setup-emacs@master


### PR DESCRIPTION
Add CI for newly released emacs 27.1