### PR TITLE
Bump version to 1.0?

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -5,7 +5,7 @@
 
 ;; Author: steckerhalter
 ;; URL: https://github.com/quelpa/quelpa
-;; Version: 0.0.1
+;; Version: 1.0
 ;; Package-Requires: ((emacs "25.1"))
 ;; Keywords: tools package management build source elpa
 


### PR DESCRIPTION
I think the version should be `1.0`? Since the latest release tag is `v1.0`, see https://github.com/quelpa/quelpa/releases.