### PR TITLE
Use quelpa-autoremove-p when no prefix given

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@
 Build and install your Emacs Lisp packages on-the-fly and directly from source.
 
 * News
-
+- 2021/03/12: Switch default from shallow clone to partial clone for git recipes 
 - 2020/03/04: Obsoleted packages will automatically be removed when newer package installed successfully
 - 2020/03/02: Emacs 24 is not supported anymore, please upgrade to use =quelpa=
 - 2020/03/02: *BREAKING CHANGE* =bootstrap.el= has been deprecated, please change your bootstrapping snippet as documented in the Installation section below.

--- a/quelpa.el
+++ b/quelpa.el
@@ -1933,8 +1933,8 @@ to install.
 
 When `quelpa' is called interactively with a prefix argument (e.g
 \\[universal-argument] \\[quelpa]) it will try to upgrade the
-given package even if the global var `quelpa-upgrade-p' is set to
-nil."
+given package and remove any old versions of it even if the
+`quelpa-upgrade-p' and `quelpa-autoremove-p' are set to nil."
   (interactive (list nil))
   (run-hooks 'quelpa-before-hook)
   (when (quelpa-setup-p) ;if init fails we do nothing

--- a/quelpa.el
+++ b/quelpa.el
@@ -1,6 +1,6 @@
 ;;; quelpa.el --- Emacs Lisp packages built directly from source
 
-;; Copyright 2014-2018, Steckerhalter
+;; Copyright 2014-2021, Steckerhalter
 ;; Copyright 2014-2015, Vasilij Schneidermann <v.schneidermann@gmail.com>
 
 ;; Author: steckerhalter
@@ -155,11 +155,18 @@ quelpa cache."
   :group 'quelpa
   :type 'boolean)
 
-(defcustom quelpa-git-clone-depth 1
+(defcustom quelpa-git-clone-depth nil
   "If non-nil shallow clone quelpa git recipes."
   :group 'quelpa
   :type '(choice (const :tag "Don't shallow clone" nil)
                  (integer :tag "Depth")))
+
+(defcustom quelpa-git-clone-partial :blobless
+  "If non-nil partially clone quelpa git recipes."
+  :group 'quelpa
+  :type '(choice (const :tag "Don't partially clone" nil)
+                 (const :tag "Blobless clone" :blobless)
+                 (const :tag "Treeless clone" :treeless)))
 
 (defcustom quelpa-upgrade-interval nil
   "Interval in days for `quelpa-upgrade-all-maybe'."
@@ -901,6 +908,7 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
                      (when-let ((branch (plist-get config :branch)))
                        (concat remote "/" branch))))
          (depth (or (plist-get config :depth) quelpa-git-clone-depth))
+         (partial (or (plist-get config :partial) quelpa-git-clone-partial))
          (force (plist-get config :force))
          (use-current-ref (plist-get config :use-current-ref)))
     (when (string-match (rx bos "file://" (group (1+ anything))) repo)
@@ -922,6 +930,9 @@ Return a cons cell whose `car' is the root and whose `cdr' is the repository."
                (append
                 `(nil "git" "clone" ,repo ,dir)
                 `("--origin" ,remote)
+                (pcase partial
+                  (:blobless `("--filter=blob:none"))
+                  (:treeless `("--filter=tree:0")))
                 (when (and depth (not (plist-get config :commit)))
                   `("--depth" ,(int-to-string depth)
                     "--no-single-branch"))
@@ -1706,7 +1717,7 @@ When FORCE is non-nil we will always update MELPA regrdless of
       (condition-case err
           (quelpa-build--checkout-git
            'package-build
-           `(:url ,quelpa-melpa-repo-url :files ("*"))
+           `(:url ,quelpa-melpa-repo-url :files ("*") :partial :treeless)
            quelpa-melpa-dir)
         (error "Failed to checkout melpa git repo: `%s'" (error-message-string err)))))
 
@@ -1933,7 +1944,7 @@ nil."
                       (quelpa-interactive-candidate))))
            (quelpa-upgrade-p (if current-prefix-arg t quelpa-upgrade-p)) ;shadow `quelpa-upgrade-p'
            (quelpa-stable-p quelpa-stable-p) ;shadow `quelpa-stable-p'
-           (quelpa-autoremove-p (if current-prefix-arg quelpa-autoremove-p nil))
+           (quelpa-autoremove-p (if current-prefix-arg t quelpa-autoremove-p))
            (cache-item (quelpa-arg-rcp arg)))
       (quelpa-parse-plist plist)
       (quelpa-parse-stable cache-item)


### PR DESCRIPTION
Problem:

When `quelpa` is combined with `use-package-quelpa`, configuring the defcustom `quelpa-autoremove-p` will have no effect when the recipe does not explicitly supply the `:autoremove` keyword. This unintuitive and inconsistent behavior was introduced in #175, this PR fixes this issue.