### PR TITLE
quelpa-package-install-file: dont ask when kill buffer

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -1812,7 +1812,12 @@ So here we replace that with `insert-file-contents' for non-tar files."
                   (lambda (file)
                     (if (string-match "\\.tar\\'" file)
                         (funcall insert-file-contents-literally-orig file)
-                      (insert-file-contents file)))))
+                      (insert-file-contents file))))
+                 (kill-buffer-orig (symbol-function 'kill-buffer))
+                 ((symbol-function 'kill-buffer)
+                  (lambda (&rest args)
+                    (set-buffer-modified-p nil)
+                    (apply kill-buffer-orig args))))
         (package-install-file file))
     (package-install-file file)))
 


### PR DESCRIPTION
Under Windows, the `insert-file-contentts` is used, however, it has a side-effect of modifying buffer content and leading to a user prompt of killing buffer or not. This is quite annoying, especially when setting up a new machine with a lot of `quelpa`  calls to install packages.
There's no easy way to avoid the prompt since the function invokes `kill-buffer` directly.
This fix is to address that issue, ignore the unreal buffer modifying and let `quelpa` continue to run without waiting.