### PR TITLE
quelpa: allow to run quelpa in parallel process with async.el

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,6 +9,7 @@
 Build and install your Emacs Lisp packages on-the-fly and directly from source.
 
 * News
+- 2021/12/28: Add new option =quelpa-use-async-p= that allows to run quelpa in external process when [[https://github.com/jwiegley/emacs-async][emacs-async]] is installed.
 - 2021/03/12: Switch default from shallow clone to partial clone for git recipes 
 - 2020/03/04: Obsoleted packages will automatically be removed when newer package installed successfully
 - 2020/03/02: Emacs 24 is not supported anymore, please upgrade to use =quelpa=

--- a/quelpa.el
+++ b/quelpa.el
@@ -318,9 +318,7 @@ already and should not be upgraded etc)."
                                    build-dir
                                    (quelpa-packages-dir)))
           (quelpa-build--message "Newer package `%s' has been installed. Not upgrading." name)
-          nil)
-      (when (fboundp 'package--quickstart-maybe-refresh)
-        (package--quickstart-maybe-refresh)))))
+          nil))))
 
 ;; --- package-build.el integration ------------------------------------------
 
@@ -1862,6 +1860,8 @@ Return new package version."
                     (quelpa-package-install (car req))))
                 requires))
         (quelpa-package-install-file file)
+        (when (fboundp 'package--quickstart-maybe-refresh)
+          (package--quickstart-maybe-refresh))
         ver))))
 
 (defun quelpa-interactive-candidate ()
@@ -2022,6 +2022,7 @@ given package and remove any old versions of it even if the
               (async-start `(lambda ()
                               (package-initialize)
                               ;; update melpa should be done in main process
+                              (setq package-quickstart ,package-quickstart)
                               (setq create-lockfiles nil)
                               (setq quelpa-update-melpa-p nil)
                               (setq quelpa-use-async-p nil)


### PR DESCRIPTION
Add new option `quelpa-use-async-p` that allows to run `quelpa` in external process when [emacs-async](https://github.com/jwiegley/emacs-async) is installed.
This provides several benefits:
- Reduce `Emacs' downtime due to fetching git repo and byte-compiling #197
- Byte compile is done in fresh process, which will be more accurate than running in current `Emacs` process

The downside is that this will require `emacs-async` to be available. When there's no `emacs-async`, we fall back to run `quelpa` in the current process.
Since `emacs-async` is a fairly thin wrapper, we can probably remove that and replace it with batch emacs processes at some points.