### PR TITLE
check tar-type before appending --format=gnu

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -1202,7 +1202,7 @@ Tests and sets variable `quelpa--tar-type' if not already set."
          "--exclude=_FOSSIL_"
          "--exclude=.bzr"
          "--exclude=.hg"
-         (append (and quelpa-build-explicit-tar-format-p '("--format=gnu"))
+         (append (and quelpa-build-explicit-tar-format-p (eq (quelpa--tar-type) 'gnu) '("--format=gnu"))
                  (or (mapcar (lambda (fn) (concat dir "/" fn)) files) (list dir)))))
 
 (defun quelpa-build--find-package-commentary (file-path)


### PR DESCRIPTION
When `quelpa-build-explicit-tar-format-p` is set to non-nil, `--format=gnu` is appended (as expected).

But this would results in an error if the system is using `bsdtar`, whose `--format` option doesn't recognize `gnu`.

This commit make sure `--format=gnu` is added only for `gnu-tar`.