### PR TITLE
Support elpa-devel versioning scheme with :version-type elpa

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,7 +9,8 @@
 Build and install your Emacs Lisp packages on-the-fly and directly from source.
 
 * News
-- 2021/03/12: Switch default from shallow clone to partial clone for git recipes 
+- 2002/09/26: Support elpa-devel version scheme (e.x, =0.27.0.20220914.164819=) with =:vertion-type quelpa= in recipes
+- 2021/03/12: Switch default from shallow clone to partial clone for git recipes
 - 2020/03/04: Obsoleted packages will automatically be removed when newer package installed successfully
 - 2020/03/02: Emacs 24 is not supported anymore, please upgrade to use =quelpa=
 - 2020/03/02: *BREAKING CHANGE* =bootstrap.el= has been deprecated, please change your bootstrapping snippet as documented in the Installation section below.


### PR DESCRIPTION
Support `elpa-devel` version if `:version-type elpa` is specified in the package recipe.
The version scheme is: `<package-version-with-atleast-3-segs>.YYYYMMDD.HHMMSS`.

For example: `(vertico :fetcher github :repo "minad/vertico" :files (:defaults "extensions/*.el") :version-type elpa)` will create a package like `vertico-0.27.0.20220914.164819`