### PR TITLE
quelpa-build: correctly append date time version to elpa version

### DIFF
--- a/quelpa.el
+++ b/quelpa.el
@@ -288,17 +288,19 @@ already and should not be upgraded etc)."
          (build-dir (expand-file-name (symbol-name name) quelpa-build-dir))
          (ver-type (plist-get (cdr rcp) :version-type))
          (files (quelpa-build--config-file-list (cdr rcp)))
-         (melpa-ver (quelpa-checkout rcp build-dir))
+         (melpa-ver (version-to-list (quelpa-checkout rcp build-dir)))
          (version
-          (cond
-           ((or (not (equal ver-type 'elpa)) quelpa-stable-p) melpa-ver)
-           (t
-            (let ((base-ver
-                   (if-let ((info (quelpa-build--pkg-info (symbol-name name) files build-dir)))
-                       (aref info 3)
-                     '(0 0 0))))
-              (while (< (length base-ver) 3) (setq base-ver (append base-ver '(0))))
-              (concat (package-version-join base-ver) "." melpa-ver))))))
+          (package-version-join
+           (cond
+            ((or (not (equal ver-type 'elpa)) quelpa-stable-p) melpa-ver)
+            (t
+             (let ((base-ver
+                    (if-let ((info (quelpa-build--pkg-info (symbol-name name)
+                                                           files build-dir)))
+                        (aref info 3)
+                      '(0 0 0))))
+               (while (< (length base-ver) 3) (setq base-ver (append base-ver '(0))))
+               (nconc base-ver melpa-ver)))))))
     (prog1
         (if version
             (quelpa-archive-file-name

--- a/test/quelpa-test.el
+++ b/test/quelpa-test.el
@@ -73,7 +73,7 @@ Defines ERT test with `quelpa-' prepended to NAME and
                                   (20140406 1613)
                                   "Emacs Lisp packages built directly from source"
                                   ((package-build (0))) nil nil "test" nil nil])))
-                             (t
+                             ((functionp 'record)
                               ;; Emacs 26+ records.
                               `((quelpa
                                  ,(record 'package-desc


### PR DESCRIPTION
Create the version list first and convert it back to a string to make sure that the version string will always be in the correct format.

Until now, some versions like `1.2.3pre ` will be joined innocently with the time stamp of `123.2312` to become `1.2.3pre.123.2312` which is not a correct version format.
This change fixes that so the string version will become `1.2.3pre123.2312` which is a correctly formated one.